### PR TITLE
add 2 new directives

### DIFF
--- a/docetl/reasoning_optimizer/directives/__init__.py
+++ b/docetl/reasoning_optimizer/directives/__init__.py
@@ -28,6 +28,7 @@ from .swap_with_code import SwapWithCodeDirective
 from .map_reduce_fusion import MapReduceFusionDirective
 from .hierarchical_reduce import HierarchicalReduceDirective
 from .cascade_filtering import CascadeFilteringDirective
+from .arbitrary_rewrite import ArbitraryRewriteDirective
 
 # Registry of all available directives
 ALL_DIRECTIVES = [
@@ -50,6 +51,7 @@ ALL_DIRECTIVES = [
     MapReduceFusionDirective(),
     HierarchicalReduceDirective(),
     CascadeFilteringDirective(),
+    ArbitraryRewriteDirective(),
 ]
 
 ALL_COST_DIRECTIVES = [
@@ -63,6 +65,7 @@ ALL_COST_DIRECTIVES = [
     MapReduceFusionDirective(),
     ChangeModelDirective(),
     CascadeFilteringDirective(),
+    ArbitraryRewriteDirective(),
 ]
 
 # Create a mapping from directive names to directive instances
@@ -153,6 +156,7 @@ __all__ = [
     "MapReduceFusionDirective",
     "HierarchicalReduceDirective",
     "CascadeFilteringDirective",
+    "ArbitraryRewriteDirective",
     "ALL_DIRECTIVES",
     "DIRECTIVE_REGISTRY", 
     "get_all_directive_strings",

--- a/docetl/reasoning_optimizer/directives/__init__.py
+++ b/docetl/reasoning_optimizer/directives/__init__.py
@@ -27,6 +27,7 @@ from .clarify_instructions import ClarifyInstructionsDirective
 from .swap_with_code import SwapWithCodeDirective
 from .map_reduce_fusion import MapReduceFusionDirective
 from .hierarchical_reduce import HierarchicalReduceDirective
+from .cascade_filtering import CascadeFilteringDirective
 
 # Registry of all available directives
 ALL_DIRECTIVES = [
@@ -48,6 +49,7 @@ ALL_DIRECTIVES = [
     SwapWithCodeDirective(),
     MapReduceFusionDirective(),
     HierarchicalReduceDirective(),
+    CascadeFilteringDirective(),
 ]
 
 ALL_COST_DIRECTIVES = [
@@ -60,6 +62,7 @@ ALL_COST_DIRECTIVES = [
     TakeHeadTailDirective(),
     MapReduceFusionDirective(),
     ChangeModelDirective(),
+    CascadeFilteringDirective(),
 ]
 
 # Create a mapping from directive names to directive instances
@@ -149,6 +152,7 @@ __all__ = [
     "SwapWithCodeDirective",
     "MapReduceFusionDirective",
     "HierarchicalReduceDirective",
+    "CascadeFilteringDirective",
     "ALL_DIRECTIVES",
     "DIRECTIVE_REGISTRY", 
     "get_all_directive_strings",

--- a/docetl/reasoning_optimizer/directives/agent_utils.py
+++ b/docetl/reasoning_optimizer/directives/agent_utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from litellm import completion, model_cost
@@ -9,30 +8,37 @@ from rich import print as rprint
 
 from docetl.operations.utils.llm import count_tokens
 
-# Configuration for how many documents to read at once
-DOCS_TO_READ_PER_ITERATION = 3
-
 
 class AgentDecision(BaseModel):
     """Schema for agent decision-making in agentic loops."""
 
-    action: Literal["read_next_docs", "output_schema"] = Field(
+    action: Literal["read_next_docs", "read_operator_doc", "output_schema"] = Field(
         ..., description="The action the agent wants to take"
     )
     reasoning: str = Field(
         ...,
         description="Explanation of why the agent chose this action and what they learned from current samples",
     )
+    operator_name: Optional[str] = Field(
+        None,
+        description="For read_operator_doc action: the operator name to read documentation for (e.g., 'map', 'filter', 'reduce')",
+    )
 
 
 class ReadNextDocTool:
     """Tool for iteratively reading documents from input data."""
 
-    def __init__(self, input_data: List[Dict], context_window: int = 32000):
+    def __init__(
+        self,
+        input_data: List[Dict],
+        context_window: int = 32000,
+        docs_per_iteration: int = 3,
+    ):
         self.input_data = input_data
         self.current_index = 0
         self.context_window = context_window
         self.total_docs = len(input_data)
+        self.docs_per_iteration = docs_per_iteration
 
     def read_next_doc(self) -> Optional[Dict]:
         """Read the next document from the input data."""
@@ -43,8 +49,10 @@ class ReadNextDocTool:
         self.current_index += 1
         return doc
 
-    def read_next_docs(self, count: int = DOCS_TO_READ_PER_ITERATION) -> List[Dict]:
+    def read_next_docs(self, count: int = None) -> List[Dict]:
         """Read the next N documents from the input data."""
+        if count is None:
+            count = self.docs_per_iteration
         docs = []
         for _ in range(count):
             if self.current_index >= len(self.input_data):
@@ -139,13 +147,27 @@ class AgenticDirectiveRunner:
         input_data: List[Dict],
         agent_llm: str = "gpt-4.1-mini",
         validation_func: Optional[callable] = None,
+        enable_operator_docs: bool = False,
     ):
         self.input_data = input_data
         self.agent_llm = agent_llm
         self.context_window = self._get_model_context_window(agent_llm)
-        self.doc_reader = ReadNextDocTool(input_data, self.context_window)
+        self.enable_operator_docs = enable_operator_docs
+        # Double the max iterations if operator docs are enabled to allow more exploration
+        self.docs_per_iteration = 3
+        self.max_iterations = 6 if enable_operator_docs else 3
+        self.doc_reader = ReadNextDocTool(
+            input_data, self.context_window, self.docs_per_iteration
+        )
         self.message_history = []
         self.validation_func = validation_func
+        self.docs_path = os.path.join(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            ),
+            "docs",
+            "operators",
+        )
 
     def _get_model_context_window(self, model: str) -> int:
         """Get the context window size for the given model."""
@@ -161,28 +183,59 @@ class AgenticDirectiveRunner:
 
         return model_cost_info.get("max_input_tokens", 32768)
 
+    def _read_operator_doc(self, operator_name: str) -> Optional[str]:
+        """
+        Read the documentation for a specific operator.
+
+        Args:
+            operator_name: Name of the operator (e.g., 'map', 'filter', 'reduce')
+
+        Returns:
+            The markdown documentation content or None if not found
+        """
+        doc_file = os.path.join(self.docs_path, f"{operator_name}.md")
+        if os.path.exists(doc_file):
+            try:
+                with open(doc_file, "r") as f:
+                    content = f.read()
+                return content
+            except Exception as e:
+                return f"Error reading documentation for {operator_name}: {str(e)}"
+        else:
+            # Try alternative names (e.g., 'parallel-map' for 'parallel_map')
+            alt_name = operator_name.replace("_", "-")
+            doc_file = os.path.join(self.docs_path, f"{alt_name}.md")
+            if os.path.exists(doc_file):
+                try:
+                    with open(doc_file, "r") as f:
+                        content = f.read()
+                    return content
+                except Exception as e:
+                    return f"Error reading documentation for {operator_name}: {str(e)}"
+            return f"Documentation not found for operator: {operator_name}"
+
     def _truncate_doc_to_tokens(self, doc: Dict, max_tokens: int) -> str:
         """
         Truncate document content to fit within the specified token limit.
-        
+
         Args:
             doc: The document dictionary to truncate
             max_tokens: Maximum number of tokens to allow
-            
+
         Returns:
             Truncated document string
         """
         doc_str = json.dumps(doc, indent=2)
         doc_tokens = estimate_token_count(doc_str, self.agent_llm)
-        
+
         if doc_tokens <= max_tokens:
             return doc_str
-        
+
         # If document is too long, truncate it
         # Estimate characters per token (rough approximation)
         chars_per_token = len(doc_str) / doc_tokens
-        target_chars = int(max_tokens * chars_per_token) 
-        
+        target_chars = int(max_tokens * chars_per_token)
+
         truncated = doc_str[:target_chars]
         return truncated + "... [truncated]"
 
@@ -206,7 +259,9 @@ class AgenticDirectiveRunner:
             {"role": "user", "content": initial_user_message},
         ]
 
-        max_iterations = min(3, len(self.input_data))  # Conservative limit for analysis
+        max_iterations = min(
+            self.max_iterations, len(self.input_data)
+        )  # Conservative limit for analysis
 
         rprint(
             f"[blue]🤖 Determining rewrite instantiation with {len(self.input_data)} documents available[/blue]"
@@ -231,9 +286,19 @@ Analyze the input samples to understand patterns, edge cases, and data character
 """
 
             # Create action guidance
-            action_guidance = f"""
+            if self.enable_operator_docs:
+                action_guidance = f"""
 Choose your next action:
-- read_next_docs: If you need more examples to understand data patterns, edge cases, or to gather more information for your analysis (reads ~{DOCS_TO_READ_PER_ITERATION} documents at once)
+- read_next_docs: If you need more examples to understand data patterns, edge cases, or to gather more information for your analysis (reads ~{self.docs_per_iteration} documents at once)
+- read_operator_doc: If you need to understand how a specific operator works, its parameters, or see examples (specify operator_name like 'map', 'filter', 'reduce')
+- output_schema: If you have sufficient examples to complete your task based on the patterns and insights you've gathered from the data
+
+Focus on quality over quantity - a few diverse, informative examples are better than many similar ones.
+"""
+            else:
+                action_guidance = f"""
+Choose your next action:
+- read_next_docs: If you need more examples to understand data patterns, edge cases, or to gather more information for your analysis (reads ~{self.docs_per_iteration} documents at once)
 - output_schema: If you have sufficient examples to complete your task based on the patterns and insights you've gathered from the data
 
 Focus on quality over quantity - a few diverse, informative examples are better than many similar ones.
@@ -274,7 +339,29 @@ Focus on quality over quantity - a few diverse, informative examples are better 
             )
 
             # Handle agent's decision
-            if decision.action == "read_next_docs":
+            if decision.action == "read_operator_doc":
+                # Agent wants to read operator documentation
+                if not self.enable_operator_docs:
+                    user_message = "Operator documentation reading is not enabled for this directive."
+                    self.message_history.append(
+                        {"role": "user", "content": user_message}
+                    )
+                elif not decision.operator_name:
+                    user_message = "Please specify which operator documentation you want to read (e.g., 'map', 'filter', 'reduce')."
+                    self.message_history.append(
+                        {"role": "user", "content": user_message}
+                    )
+                else:
+                    rprint(
+                        f"[blue]📖 Agent reading documentation for operator: {decision.operator_name}[/blue]"
+                    )
+                    doc_content = self._read_operator_doc(decision.operator_name)
+                    user_message = f"Documentation for '{decision.operator_name}' operator:\n\n{doc_content}\n\nAnalyze this documentation to understand how to use this operator effectively."
+                    self.message_history.append(
+                        {"role": "user", "content": user_message}
+                    )
+
+            elif decision.action == "read_next_docs":
                 # Agent wants to analyze more data
                 next_docs = self.doc_reader.read_next_docs()
                 if not next_docs:

--- a/docetl/reasoning_optimizer/directives/arbitrary_rewrite.py
+++ b/docetl/reasoning_optimizer/directives/arbitrary_rewrite.py
@@ -1,0 +1,357 @@
+import json
+from typing import Dict, List, Type
+
+from pydantic import BaseModel, Field
+
+from docetl.reasoning_optimizer.instantiate_schemas import (
+    ArbitraryRewriteInstantiateSchema,
+)
+from docetl.reasoning_optimizer.op_descriptions import get_all_operator_descriptions
+
+from .agent_utils import AgenticDirectiveRunner
+from .base import Directive, DirectiveTestCase
+
+
+class ArbitraryRewriteDirective(Directive):
+    name: str = Field(
+        default="arbitrary_rewrite", description="The name of the directive"
+    )
+    formal_description: str = Field(
+        default="Pipeline => Modified Pipeline (search/replace edits)"
+    )
+    nl_description: str = Field(
+        default="Allows the agent to make arbitrary edits to the pipeline using search/replace operations on the JSON representation. The agent can add, modify, remove, or replace operations to optimize for cost, accuracy, or both. This is a catch-all directive for optimizations that don't fit into other specific directive patterns."
+    )
+    when_to_use: str = Field(
+        default="When you identify obvious optimizations that can make the pipeline cheaper or more accurate, but they don't fit into existing directive patterns. Use this for complex multi-operation changes, reordering operations, consolidating redundant operations, or making systematic improvements across the pipeline."
+    )
+
+    instantiate_schema_type: Type[BaseModel] = Field(
+        default=ArbitraryRewriteInstantiateSchema
+    )
+
+    example: str = Field(
+        default="""
+        # Example 1: Consolidating Redundant Operations
+        Original Pipeline JSON (formatted for readability):
+        [
+            {
+                "name": "extract_names",
+                "type": "map",
+                "model": "gpt-4o",
+                "prompt": "Extract all person names from: {{ input.text }}",
+                "output": {"schema": {"names": "list[string]"}}
+            },
+            {
+                "name": "extract_locations",
+                "type": "map",
+                "model": "gpt-4o",
+                "prompt": "Extract all locations from: {{ input.text }}",
+                "output": {"schema": {"locations": "list[string]"}}
+            },
+            {
+                "name": "extract_dates",
+                "type": "map",
+                "model": "gpt-4o",
+                "prompt": "Extract all dates from: {{ input.text }}",
+                "output": {"schema": {"dates": "list[string]"}}
+            }
+        ]
+
+        Example SearchReplaceEdits (agent recognizes redundant LLM calls):
+        search_replace_edits=[
+            SearchReplaceEdit(
+                search='    {\\n        "name": "extract_names",\\n        "type": "map",\\n        "model": "gpt-4o",\\n        "prompt": "Extract all person names from: {{ input.text }}",\\n        "output": {"schema": {"names": "list[string]"}}\\n    },\\n    {\\n        "name": "extract_locations",\\n        "type": "map",\\n        "model": "gpt-4o",\\n        "prompt": "Extract all locations from: {{ input.text }}",\\n        "output": {"schema": {"locations": "list[string]"}}\\n    },\\n    {\\n        "name": "extract_dates",\\n        "type": "map",\\n        "model": "gpt-4o",\\n        "prompt": "Extract all dates from: {{ input.text }}",\\n        "output": {"schema": {"dates": "list[string]"}}\\n    }',
+                replace='    {\\n        "name": "extract_all_entities",\\n        "type": "map",\\n        "model": "gpt-4o-mini",\\n        "prompt": "Extract all entities from the text:\\\\n{{ input.text }}\\\\n\\\\nReturn names, locations, and dates.",\\n        "output": {\\n            "schema": {\\n                "names": "list[string]",\\n                "locations": "list[string]",\\n                "dates": "list[string]"\\n            }\\n        }\\n    }',
+                reasoning="Consolidate three separate GPT-4o calls into one GPT-4o-mini call"
+            )
+        ]
+
+        # Example 2: Reordering for Efficiency
+        Original Pipeline JSON:
+        [
+            {
+                "name": "summarize_documents",
+                "type": "map",
+                "model": "gpt-4o",
+                "prompt": "Summarize this document: {{ input.full_text }}",
+                "output": {"schema": {"summary": "string"}}
+            },
+            {
+                "name": "filter_relevant",
+                "type": "filter",
+                "model": "gpt-4o-mini",
+                "prompt": "Is this document about technology? {{ input.full_text }}",
+                "output": {"schema": {"is_relevant": "boolean"}}
+            }
+        ]
+
+        Example SearchReplaceEdits (agent recognizes inefficient ordering):
+        search_replace_edits=[
+            SearchReplaceEdit(
+                search='{\\n        "name": "summarize_documents",\\n        "type": "map",\\n        "model": "gpt-4o",\\n        "prompt": "Summarize this document: {{ input.full_text }}",\\n        "output": {"schema": {"summary": "string"}}\\n    },\\n    {\\n        "name": "filter_relevant",',
+                replace='{\\n        "name": "filter_relevant",',
+                reasoning="Remove summarize operation from before filter"
+            ),
+            SearchReplaceEdit(
+                search='"output": {"schema": {"is_relevant": "boolean"}}\\n    }',
+                replace='"output": {"schema": {"is_relevant": "boolean"}}\\n    },\\n    {\\n        "name": "summarize_documents",\\n        "type": "map",\\n        "model": "gpt-4o",\\n        "prompt": "Summarize this technology document: {{ input.full_text }}",\\n        "output": {"schema": {"summary": "string"}}\\n    }',
+                reasoning="Add summarization after filter to only process relevant documents"
+            )
+        ]
+
+        Note: The agent must provide exact string matches including whitespace for the search strings.
+        """
+    )
+
+    test_cases: List[DirectiveTestCase] = Field(
+        default_factory=lambda: [
+            DirectiveTestCase(
+                name="consolidate_operations",
+                description="Should identify and consolidate redundant operations",
+                input_config=[
+                    {
+                        "name": "extract_a",
+                        "type": "map",
+                        "model": "gpt-4o",
+                        "prompt": "Extract A from: {{ input.text }}",
+                        "output": {"schema": {"a": "string"}},
+                    },
+                    {
+                        "name": "extract_b",
+                        "type": "map",
+                        "model": "gpt-4o",
+                        "prompt": "Extract B from: {{ input.text }}",
+                        "output": {"schema": {"b": "string"}},
+                    },
+                ],
+                target_ops=[],  # Analyzes entire pipeline
+                expected_behavior="Should propose consolidating the two extraction operations into one",
+                should_pass=True,
+            )
+        ]
+    )
+
+    def __eq__(self, other):
+        return isinstance(other, ArbitraryRewriteDirective)
+
+    def __hash__(self):
+        return hash("ArbitraryRewriteDirective")
+
+    def _order_ops_by_pipeline_steps(
+        self, ops_list: List[Dict], pipeline_code: Dict = None
+    ) -> List[Dict]:
+        """Order operations according to pipeline steps if pipeline_code is provided."""
+        if not (
+            pipeline_code
+            and "pipeline" in pipeline_code
+            and "steps" in pipeline_code["pipeline"]
+        ):
+            return ops_list
+
+        # Get the order from pipeline steps
+        steps = pipeline_code["pipeline"]["steps"]
+        step_order = []
+        for step in steps:
+            if isinstance(step, dict) and "operations" in step:
+                step_order.extend(step["operations"])
+            elif isinstance(step, str):
+                step_order.append(step)
+
+        # Create a mapping of op names to ops
+        ops_by_name = {op["name"]: op for op in ops_list}
+
+        # Reorder ops according to pipeline steps
+        ordered_ops = []
+        for op_name in step_order:
+            if op_name in ops_by_name:
+                ordered_ops.append(ops_by_name[op_name])
+
+        # Add any ops that weren't in steps (shouldn't happen, but just in case)
+        for op in ops_list:
+            if op not in ordered_ops:
+                ordered_ops.append(op)
+
+        return ordered_ops
+
+    def to_string_for_instantiate(
+        self, pipeline_ops: List[Dict], pipeline_code: Dict = None
+    ) -> str:
+        """Generate prompt for agent to analyze pipeline and propose edits."""
+
+        # Convert ops to pretty JSON string for display (already ordered by instantiate)
+        pipeline_json = json.dumps(pipeline_ops, indent=4)
+
+        return (
+            f"You are an expert at optimizing data processing pipelines for cost and accuracy.\n\n"
+            f"Current Pipeline Operations (as JSON array):\n"
+            f"{pipeline_json}\n\n"
+            f"Your task is to analyze this pipeline and propose search/replace edits to optimize it.\n\n"
+            f"IMPORTANT: The above JSON is ONLY the operations array. When creating search/replace edits, "
+            f"work with this exact JSON structure. Do not include pipeline wrapper or other fields.\n\n"
+            f"You have access to:\n"
+            f"1. Sample input data through read_next_docs() - to understand data patterns and flow\n"
+            f"2. Operator documentation through read_operator_doc(operator_name) - to learn about available operators\n\n"
+            f"IMPORTANT: Read documentation for no more than 2 operators before analyzing sample data to get a sense for how best to rewrite the pipeline to improve cost or accuracy (ideally both).\n\n"
+            f"Use these tools to:\n"
+            f"1. Understand the data flow through the pipeline\n"
+            f"2. Identify inefficiencies or redundancies\n"
+            f"3. Find opportunities for consolidation or reordering\n"
+            f"4. Determine if cheaper models could be used\n"
+            f"5. Discover new operators that might be more efficient\n\n"
+            f"IMPORTANT: You will provide search/replace edits that work on the JSON string representation.\n"
+            f"Each edit consists of:\n"
+            f"- search: An exact string to find in the JSON (including whitespace)\n"
+            f"- replace: The string to replace it with (can be empty to delete)\n"
+            f"- reasoning: Why this edit improves the pipeline\n\n"
+            f"The edits will be applied sequentially to the JSON string, then parsed back to operations.\n\n"
+            f"Guidelines for search/replace:\n"
+            f"- The search string must match EXACTLY including all whitespace, quotes, brackets, etc.\n"
+            f"- You can delete operations by replacing them with empty string (but be careful with commas)\n"
+            f"- You can add operations by replacing closing brackets with new operations\n"
+            f"- You can reorder by using multiple search/replace operations\n"
+            f"- Each edit operates on the result of the previous edit\n\n"
+            f"Types of optimizations to look for:\n"
+            f"- Redundant operations that could be consolidated\n"
+            f"- Operations in suboptimal order (e.g., expensive operations before filters)\n"
+            f"- Opportunities to use cheaper models\n"
+            f"- Complex operations that could be broken into simpler steps\n"
+            f"- Independent operations that could be parallelized\n\n"
+            f"Examples:\n"
+            f"{self.example}\n\n"
+            f"Analyze the pipeline and sample data strategically. When you have identified optimizations, "
+            f"output your proposed edits as an ArbitraryRewriteInstantiateSchema.\n\n"
+            f"Remember: Your search strings must match the JSON exactly as it appears above."
+        )
+
+    def llm_instantiate(
+        self,
+        pipeline_ops: List[Dict],
+        input_file_path: str,
+        agent_llm: str,
+        message_history: list = [],
+        pipeline_code: Dict = None,
+    ) -> tuple:
+        """Use agentic approach to analyze pipeline and generate edits."""
+        # Load sample input data
+        try:
+            with open(input_file_path, "r") as f:
+                input_data = json.load(f)
+
+            if not isinstance(input_data, list) or len(input_data) == 0:
+                raise ValueError(
+                    "Input file must contain a non-empty list of sample data"
+                )
+
+        except Exception as e:
+            raise Exception(
+                f"Failed to load input data from {input_file_path}: {str(e)}"
+            )
+
+        # Set up agentic runner with operator doc reading enabled
+        runner = AgenticDirectiveRunner(
+            input_data=input_data,
+            agent_llm=agent_llm,
+            enable_operator_docs=True,  # Enable reading operator documentation
+        )
+
+        # Create system prompt with operator descriptions
+        operator_descriptions = get_all_operator_descriptions()
+        system_prompt = (
+            "You are an expert at optimizing data processing pipelines. "
+            "You analyze pipeline structures and data flow to identify opportunities "
+            "for cost reduction and accuracy improvement through strategic search/replace edits on the JSON representation.\n\n"
+            f"{operator_descriptions}"
+        )
+
+        # Create initial user message
+        initial_message = self.to_string_for_instantiate(pipeline_ops, pipeline_code)
+
+        # Run the agentic loop
+        try:
+            schema, updated_message_history = runner.run_agentic_loop(
+                system_prompt=system_prompt,
+                initial_user_message=initial_message,
+                response_schema=ArbitraryRewriteInstantiateSchema,
+            )
+
+            # Update message history
+            message_history.extend(updated_message_history)
+
+            return schema, message_history
+
+        except Exception as e:
+            raise Exception(
+                f"Failed to instantiate arbitrary_rewrite directive: {str(e)}"
+            )
+
+    def apply(
+        self,
+        ops_list: List[Dict],
+        rewrite: ArbitraryRewriteInstantiateSchema,
+    ) -> List[Dict]:
+        """Apply the search/replace edits to the pipeline."""
+        # Convert operations list to JSON string with consistent formatting
+        pipeline_json = json.dumps(ops_list, indent=4)
+
+        # Apply each search/replace edit in sequence
+        for i, edit in enumerate(rewrite.search_replace_edits):
+            if edit.search in pipeline_json:
+                pipeline_json = pipeline_json.replace(
+                    edit.search, edit.replace, 1
+                )  # Replace first occurrence only
+            else:
+                # Log warning but continue with other edits
+                print(
+                    f"Warning: Search string not found in edit {i+1}: {edit.search[:50]}..."
+                )
+
+        # Parse the modified JSON back to operations list
+        try:
+            new_ops_list = json.loads(pipeline_json)
+            if not isinstance(new_ops_list, list):
+                raise ValueError("Pipeline must be a list of operations")
+            return new_ops_list
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Failed to parse pipeline after edits. The search/replace operations resulted in invalid JSON: {e}\n"
+                f"Modified JSON:\n{pipeline_json[:500]}..."
+            )
+
+    def instantiate(
+        self,
+        operators: List[Dict],
+        target_ops: List[str] = None,
+        agent_llm: str = "gpt-4o-mini",
+        message_history: list = [],
+        **kwargs,
+    ) -> tuple:
+        """
+        Main method that orchestrates directive instantiation.
+        For ArbitraryRewrite, we analyze the entire pipeline rather than specific target ops.
+        """
+        input_file_path = kwargs.get("input_file_path", None)
+        pipeline_code = kwargs.get("pipeline_code", None)
+
+        if not input_file_path:
+            raise ValueError(
+                "input_file_path is required for ArbitraryRewrite directive"
+            )
+
+        # Order ops according to pipeline steps before everything else
+        ordered_ops = self._order_ops_by_pipeline_steps(operators, pipeline_code)
+
+        # Step 1: Agent analyzes pipeline and generates edits
+        rewrite, message_history = self.llm_instantiate(
+            ordered_ops,
+            input_file_path,
+            agent_llm,
+            message_history,
+            pipeline_code,
+        )
+
+        # Step 2: Apply the edits
+        return (
+            self.apply(ordered_ops, rewrite),
+            message_history,
+        )

--- a/docetl/reasoning_optimizer/directives/cascade_filtering.py
+++ b/docetl/reasoning_optimizer/directives/cascade_filtering.py
@@ -1,0 +1,442 @@
+import json
+import re
+from copy import deepcopy
+from typing import Dict, List, Type
+
+from pydantic import BaseModel, Field
+
+from docetl.reasoning_optimizer.instantiate_schemas import (
+    CascadeFilteringInstantiateSchema,
+)
+
+from .agent_utils import AgenticDirectiveRunner
+from .base import Directive, DirectiveTestCase
+
+
+class CascadeFilteringDirective(Directive):
+    name: str = Field(
+        default="cascade_filtering", description="The name of the directive"
+    )
+    formal_description: str = Field(
+        default="Filter => (Code Filter* -> Filter(gpt-5-nano)* ->) Filter"
+    )
+    nl_description: str = Field(
+        default="Optimizes filtering costs by injecting a cascade of cheaper filters before the main filter. Starts with deterministic code filters (cheapest), then gpt-5-nano filters (ordered by prompt length), before the original expensive filter. Pre-filters prioritize high recall (rarely rejecting valid documents) and can have lower precision (okay to let through some invalid docs that the main filter will catch)."
+    )
+    when_to_use: str = Field(
+        default="When you have an expensive Filter operation (using costly models or complex prompts) and the data contains patterns that allow for cheaper pre-filtering. The pre-filters must have high recall (not dropping valid documents) but can have lower precision, as the final filter provides the actual precision."
+    )
+
+    instantiate_schema_type: Type[BaseModel] = Field(
+        default=CascadeFilteringInstantiateSchema
+    )
+
+    example: str = Field(
+        default="""
+        # Example 1: Disjunction - Legal Document Relevance Filter
+        Target Operation:
+        - name: filter_litigation_relevant_docs
+          type: filter
+          model: gpt-4o
+          prompt: |
+            Determine if this document is relevant to our patent litigation case.
+
+            The document is relevant if it contains ANY of:
+            1. Prior art references dated before 2015-03-15 describing similar technology
+            2. Internal emails discussing the patent claims or invalidity arguments
+            3. Technical specifications that contradict our patent claims
+            4. License agreements mentioning the patents-in-suit
+            5. Expert testimony or declarations about the technology
+            6. Financial damages calculations or royalty discussions
+
+            Patent numbers in suit: 8,123,456 and 9,234,567
+            Technology area: adaptive bitrate streaming for video delivery
+
+            Document: {{ input.document_text }}
+            Metadata: {{ input.document_metadata }}
+          output:
+            schema:
+              is_relevant: boolean
+
+        Example InstantiateSchema (agent recognizes the OR conditions can be split):
+        CascadeFilteringInstantiateSchema(
+            code_pre_filters=[
+                CodePreFilter(
+                    name="has_patent_numbers",
+                    code=\"\"\"def transform(input_doc):
+    text = (input_doc.get('document_text', '') + ' ' + str(input_doc.get('document_metadata', {}))).lower()
+    # If patent numbers are mentioned, likely relevant
+    return '8,123,456' in text or '9,234,567' in text or 'patent' in text\"\"\",
+                    reasoning="Documents mentioning our patent numbers or patents in general might be relevant"
+                ),
+                CodePreFilter(
+                    name="has_tech_or_legal_terms",
+                    code=\"\"\"def transform(input_doc):
+    text = input_doc.get('document_text', '').lower()
+    # Must have streaming tech or legal terms to possibly be relevant
+    terms = ['streaming', 'bitrate', 'video', 'codec', 'prior art', 'license',
+             'damages', 'royalty', 'testimony', 'expert', 'invalidity']
+    return any(term in text for term in terms)\"\"\",
+                    reasoning="Documents without technical or legal terminology cannot be relevant"
+                )
+            ],
+            llm_pre_filters=[
+                LLMPreFilter(
+                    name="check_prior_art_date",
+                    prompt="Does this mention technology from before March 2015? {{ input.document_metadata }} If yes; set 'keep' to true. If no; set 'keep' to false.",
+                    reasoning="Prior art must predate the patent filing"
+                ),
+                LLMPreFilter(
+                    name="check_email_discussion",
+                    prompt="Is this an email or discussion about patents? {{ input.document_text }} If yes; set 'keep' to true. If no; set 'keep' to false.",
+                    reasoning="Internal emails about patents might be relevant"
+                ),
+                LLMPreFilter(
+                    name="check_technical_specs",
+                    prompt="Does this contain technical specifications? {{ input.document_text }} If yes; set 'keep' to true. If no; set 'keep' to false.",
+                    reasoning="Technical specs might contradict our claims"
+                )
+            ],
+            analysis_summary="Filter has 6 OR criteria. Pre-filters check each criterion cheaply, eliminating 70% of documents before expensive analysis"
+        )
+
+        # Example 2: Complex Reasoning - Misinformation Detection Filter
+        Target Operation:
+        - name: filter_misinformation
+          type: filter
+          model: gpt-4o
+          prompt: |
+            Analyze this social media post to determine if it contains health misinformation.
+
+            Consider:
+            - Claims that contradict scientific consensus
+            - Misleading statistics or cherry-picked data
+            - Conspiracy theories about health organizations
+            - Dangerous medical advice without proper qualifications
+            - Manipulation of legitimate studies to support false conclusions
+            - Emotional manipulation to spread fear about vaccines/treatments
+
+            Requires nuanced understanding of:
+            - Context and speaker credibility
+            - Difference between opinion and factual claims
+            - Satirical vs serious content
+            - Cultural/religious beliefs vs dangerous misinformation
+
+            Post: {{ input.post_content }}
+            Author Profile: {{ input.author_info }}
+            Engagement Metrics: {{ input.engagement_stats }}
+          output:
+            schema:
+              is_misinformation: boolean
+
+        Example InstantiateSchema (agent deduces proxy filters for complex reasoning):
+        CascadeFilteringInstantiateSchema(
+            code_pre_filters=[
+                CodePreFilter(
+                    name="has_health_content",
+                    code=\"\"\"def transform(input_doc):
+    text = input_doc.get('post_content', '').lower()
+    # Must mention health/medical topics to potentially be health misinfo
+    health_terms = ['vaccine', 'covid', 'cancer', 'cure', 'treatment', 'doctor',
+                    'medical', 'health', 'disease', 'virus', 'immune', 'pharmaceutical']
+    return any(term in text for term in health_terms)\"\"\",
+                    reasoning="Posts without health-related content cannot be health misinformation"
+                ),
+                CodePreFilter(
+                    name="has_claims_language",
+                    code=\"\"\"def transform(input_doc):
+    text = input_doc.get('post_content', '').lower()
+    # Look for language that makes claims rather than just sharing experience
+    claim_markers = ['proven', 'studies show', 'research', 'scientists', 'they don\\'t want',
+                     'truth about', 'actually', 'fact', 'evidence', 'causes', 'prevents']
+    return any(marker in text for marker in claim_markers) or '!' in text\"\"\",
+                    reasoning="Posts without claim-making language are less likely to be misinformation"
+                )
+            ],
+            llm_pre_filters=[
+                LLMPreFilter(
+                    name="check_medical_claims",
+                    prompt="Does this post make medical or health claims? {{ input.post_content }} If yes; set 'keep' to true. If no; set 'keep' to false.",
+                    reasoning="Posts making medical claims need detailed analysis"
+                ),
+                LLMPreFilter(
+                    name="check_high_engagement",
+                    prompt="Is this a high-engagement post (>1000 shares or viral)? {{ input.engagement_stats }} If yes; set 'keep' to true. If no; set 'keep' to false.",
+                    reasoning="High-engagement posts have more potential for harm if they contain misinformation"
+                )
+            ],
+            analysis_summary="Complex task requiring reasoning about credibility, context, and scientific accuracy. Pre-filters identify posts that definitely need review (30% of total) by checking for health content, claim-making language, and viral spread potential"
+        )
+        """
+    )
+
+    test_cases: List[DirectiveTestCase] = Field(
+        default_factory=lambda: [
+            DirectiveTestCase(
+                name="single_filter_cascade",
+                description="Should create cascade of filters before expensive filter",
+                input_config={
+                    "name": "filter_quality",
+                    "type": "filter",
+                    "model": "gpt-4o",
+                    "prompt": "Is this a high-quality research paper? Paper: {{ input.paper }}",
+                    "output": {"schema": {"is_quality": "boolean"}},
+                },
+                target_ops=["filter_quality"],
+                expected_behavior="Should inject cheaper pre-filters (code and/or gpt-5-nano) before the expensive gpt-4o filter",
+                should_pass=True,
+            )
+        ]
+    )
+
+    def __eq__(self, other):
+        return isinstance(other, CascadeFilteringDirective)
+
+    def __hash__(self):
+        return hash("CascadeFilteringDirective")
+
+    def _extract_input_keys(self, prompt: str) -> List[str]:
+        """Extract input field names from a Jinja2 prompt template."""
+        # Match {{ input.fieldname }} patterns
+        pattern = r"\{\{\s*input\.(\w+)\s*\}\}"
+        matches = re.findall(pattern, prompt)
+        return list(set(matches))  # Return unique field names
+
+    def to_string_for_instantiate(
+        self, target_ops_configs: List[Dict], pipeline_code: Dict = None
+    ) -> str:
+        """Generate prompt for agent to analyze data and create cascade filters."""
+        assert (
+            len(target_ops_configs) == 1
+        ), "CascadeFiltering directive only supports single target operation"
+        assert (
+            target_ops_configs[0]["type"] == "filter"
+        ), "Target operation must be a filter"
+
+        op = target_ops_configs[0]
+        input_keys = self._extract_input_keys(op.get("prompt", ""))
+
+        pipeline_context = ""
+        if pipeline_code:
+            pipeline_context = f"""
+Pipeline Context:
+{json.dumps(pipeline_code, indent=2)}
+
+The target filter '{op['name']}' fits into this broader pipeline. Consider what types of documents flow into this filter and what the downstream operations expect.
+"""
+
+        return (
+            f"You are an expert at optimizing filter operations by creating efficient filter cascades.\n\n"
+            f"Target Filter Operation:\n"
+            f"{json.dumps(op, indent=2)}\n\n"
+            f"Input fields used in the original prompt: {input_keys}\n\n"
+            f"{pipeline_context}\n"
+            f"Your task is to analyze sample input data and create a cascade of cheaper pre-filters that can eliminate many documents before they reach the expensive main filter.\n\n"
+            f"You will be given access to sample input data through a read_next_docs() function. Use this to:\n"
+            f"1. Understand what documents should pass vs. fail the main filter\n"
+            f"2. Identify simple patterns that can predict filter outcomes\n"
+            f"3. Design code-based filters for deterministic patterns (cheapest)\n"
+            f"4. Design gpt-5-nano filters for simple semantic patterns (still cheap)\n\n"
+            f"Guidelines for code_pre_filters:\n"
+            f"- Must be Python functions with signature: def transform(input_doc): return bool\n"
+            f"- Should use regex, keyword matching, length checks, or simple logic\n"
+            f"- Must be deterministic and fast\n"
+            f"- Return True to keep the document, False to filter it out\n"
+            f"- Access document fields using input_doc.get('fieldname', default_value)\n\n"
+            f"Guidelines for llm_pre_filters:\n"
+            f"- Must be Jinja2 templates that reference input fields using {{{{ input.fieldname }}}} syntax\n"
+            f"- Must reference the same input fields as the original prompt\n"
+            f"- Should be simple, focused prompts that elicit a yes/no or true/false response\n"
+            f"- Keep prompts SHORT - they will be ordered by length automatically\n"
+            f"- Must use at least one of these input fields: {input_keys}\n\n"
+            f"General Guidelines:\n"
+            f"- Pre-filters MUST have HIGH RECALL (rarely reject documents that would pass the main filter)\n"
+            f"- Pre-filters can have LOWER PRECISION (okay to let through documents that fail - the main filter will catch them)\n"
+            f"- When in doubt, let the document through (return True) - false negatives are worse than false positives\n\n"
+            f"- All documents will have the same keys. So don't write code that checks if a particular key exists in a document or not.\n"
+            f"Example transformation:\n"
+            f"{self.example}\n\n"
+            f"Analyze samples strategically - look for patterns that distinguish documents that pass vs fail the filter.\n"
+            f"When you have identified enough patterns to create effective pre-filters, output your result.\n\n"
+            f"Remember: The goal is to reduce costs by filtering out documents early with cheaper methods while maintaining the same final accuracy."
+        )
+
+    def llm_instantiate(
+        self,
+        target_ops_configs: List[Dict],
+        input_file_path: str,
+        agent_llm: str,
+        message_history: list = [],
+        pipeline_code: Dict = None,
+    ) -> tuple:
+        """Use agentic approach to analyze data and generate cascade filters."""
+        # Load sample input data
+        try:
+            with open(input_file_path, "r") as f:
+                input_data = json.load(f)
+
+            if not isinstance(input_data, list) or len(input_data) == 0:
+                raise ValueError(
+                    "Input file must contain a non-empty list of sample data"
+                )
+
+        except Exception as e:
+            raise Exception(
+                f"Failed to load input data from {input_file_path}: {str(e)}"
+            )
+
+        # Extract input keys from original prompt for validation
+        original_prompt = target_ops_configs[0].get("prompt", "")
+        expected_input_keys = self._extract_input_keys(original_prompt)
+
+        def validate_llm_prompts(schema_instance):
+            """Validate that LLM prompts use correct input fields."""
+            for llm_filter in schema_instance.llm_pre_filters:
+                used_keys = set(
+                    re.findall(r"\{\{\s*input\.(\w+)\s*\}\}", llm_filter.prompt)
+                )
+                invalid_keys = used_keys - set(expected_input_keys)
+                if invalid_keys:
+                    raise ValueError(
+                        f"LLM filter '{llm_filter.name}' uses invalid input fields: {invalid_keys}. "
+                        f"Available fields from original prompt: {expected_input_keys}"
+                    )
+                if not used_keys:
+                    raise ValueError(
+                        f"LLM filter '{llm_filter.name}' must reference at least one input field "
+                        f"from the original prompt: {expected_input_keys}"
+                    )
+
+        # Set up agentic runner with validation
+        runner = AgenticDirectiveRunner(
+            input_data=input_data,
+            agent_llm=agent_llm,
+            validation_func=validate_llm_prompts,
+        )
+
+        # Create system prompt
+        system_prompt = (
+            "You are an expert at optimizing data processing pipelines by creating efficient filter cascades. "
+            "You analyze data to identify patterns that allow for cheap pre-filtering before expensive operations. "
+            "Your goal is to reduce costs while maintaining accuracy by using progressively more expensive filters."
+        )
+
+        # Create initial user message
+        initial_message = self.to_string_for_instantiate(
+            target_ops_configs, pipeline_code
+        )
+
+        # Run the agentic loop
+        try:
+            schema, updated_message_history = runner.run_agentic_loop(
+                system_prompt=system_prompt,
+                initial_user_message=initial_message,
+                response_schema=CascadeFilteringInstantiateSchema,
+            )
+
+            # Update message history
+            message_history.extend(updated_message_history)
+
+            return schema, message_history
+
+        except Exception as e:
+            raise Exception(
+                f"Failed to instantiate cascade_filtering directive: {str(e)}"
+            )
+
+    def apply(
+        self,
+        global_default_model: str,
+        ops_list: List[Dict],
+        target_ops: List[str],
+        rewrite: CascadeFilteringInstantiateSchema,
+    ) -> List[Dict]:
+        """Apply the directive by injecting pre-filters before the target filter."""
+        new_ops_list = []
+
+        for op in ops_list:
+            if op["name"] in target_ops:
+                # First, add all code filters
+                for i, code_filter in enumerate(rewrite.code_pre_filters):
+                    code_filter_op = {
+                        "name": f"{code_filter.name}_{op['name']}",
+                        "type": "code_filter",
+                        "code": code_filter.code,
+                    }
+                    new_ops_list.append(code_filter_op)
+
+                # Sort LLM filters by prompt length (shortest first for cost efficiency)
+                sorted_llm_filters = sorted(
+                    rewrite.llm_pre_filters, key=lambda f: len(f.prompt)
+                )
+
+                # Then, add all LLM filters (using gpt-5-nano)
+                for i, llm_filter in enumerate(sorted_llm_filters):
+                    llm_filter_op = {
+                        "name": f"{llm_filter.name}_{op['name']}",
+                        "type": "filter",
+                        "model": "gpt-5-nano",
+                        "prompt": llm_filter.prompt,
+                        "output": {"schema": {"keep": "boolean"}},
+                    }
+                    new_ops_list.append(llm_filter_op)
+
+                # Finally, add the original filter
+                new_ops_list.append(deepcopy(op))
+            else:
+                # Keep other operations as-is
+                new_ops_list.append(deepcopy(op))
+
+        return new_ops_list
+
+    def instantiate(
+        self,
+        operators: List[Dict],
+        target_ops: List[str],
+        agent_llm: str,
+        message_history: list = [],
+        global_default_model: str = None,
+        **kwargs,
+    ) -> tuple:
+        """
+        Main method that orchestrates directive instantiation:
+        1. Use agentic approach to analyze data and generate cascade filters
+        2. Apply the transformation by injecting pre-filters
+        """
+        assert (
+            len(target_ops) == 1
+        ), "CascadeFiltering directive requires exactly one target operation"
+
+        input_file_path = kwargs.get("input_file_path", None)
+        pipeline_code = kwargs.get("pipeline_code", None)
+
+        if not input_file_path:
+            raise ValueError(
+                "input_file_path is required for CascadeFiltering directive"
+            )
+
+        # Get configuration for target operation
+        target_ops_configs = [op for op in operators if op["name"] in target_ops]
+
+        if not target_ops_configs:
+            raise ValueError(f"Target operation {target_ops[0]} not found in operators")
+
+        if target_ops_configs[0]["type"] != "filter":
+            raise ValueError(
+                f"Target operation {target_ops[0]} must be a filter operation"
+            )
+
+        # Step 1: Agent analyzes data and generates cascade filters
+        rewrite, message_history = self.llm_instantiate(
+            target_ops_configs,
+            input_file_path,
+            agent_llm,
+            message_history,
+            pipeline_code,
+        )
+
+        # Step 2: Apply transformation
+        return (
+            self.apply(global_default_model, operators, target_ops, rewrite),
+            message_history,
+        )

--- a/docetl/reasoning_optimizer/instantiate_schemas.py
+++ b/docetl/reasoning_optimizer/instantiate_schemas.py
@@ -1218,10 +1218,10 @@ class SearchReplaceEdit(BaseModel):
         ...,
         description="The string to replace the search string with. Can be empty string to delete content.",
     )
-    reasoning: str = Field(
-        ...,
-        description="Explanation of why this edit improves the pipeline (cost, accuracy, or both)",
-    )
+    # reasoning: str = Field(
+    #     ...,
+    #     description="Explanation of why this edit improves the pipeline (cost, accuracy, or both)",
+    # )
 
 
 class ArbitraryRewriteInstantiateSchema(BaseModel):

--- a/docetl/reasoning_optimizer/instantiate_schemas.py
+++ b/docetl/reasoning_optimizer/instantiate_schemas.py
@@ -1202,3 +1202,42 @@ class MapReduceFusionInstantiateSchema(BaseModel):
                 + new_key
                 + " }}' instead."
             )
+
+
+class SearchReplaceEdit(BaseModel):
+    """
+    Represents a single search/replace edit to the pipeline operations JSON string.
+    Works like a text editor's find-and-replace on the JSON representation.
+    """
+
+    search: str = Field(
+        ...,
+        description="The exact string to search for in the JSON representation of the pipeline. Must match exactly including whitespace.",
+    )
+    replace: str = Field(
+        ...,
+        description="The string to replace the search string with. Can be empty string to delete content.",
+    )
+    reasoning: str = Field(
+        ...,
+        description="Explanation of why this edit improves the pipeline (cost, accuracy, or both)",
+    )
+
+
+class ArbitraryRewriteInstantiateSchema(BaseModel):
+    """
+    Schema for arbitrary pipeline rewrites using search/replace edits.
+
+    This directive allows the agent to make free-form edits to the pipeline
+    by performing string search/replace operations on the JSON representation.
+    The pipeline is converted to a JSON string, edits are applied, then parsed back.
+    """
+
+    search_replace_edits: List[SearchReplaceEdit] = Field(
+        ...,
+        description="List of search/replace edits to apply to the pipeline JSON string. Applied in order, each operating on the result of the previous edit.",
+    )
+    overall_strategy: str = Field(
+        ...,
+        description="High-level explanation of the optimization strategy and expected improvements",
+    )

--- a/docetl/reasoning_optimizer/op_descriptions.py
+++ b/docetl/reasoning_optimizer/op_descriptions.py
@@ -519,9 +519,9 @@ op_code_map = Operator(
             import re
             text = input_doc.get('content', '')
             # Extract words that are all caps (potential keywords)
-            keywords = re.findall(r'\b[A-Z]{2,}\b', text)
+            keywords = re.findall(r'\\b[A-Z]{2,}\\b', text)
             # Extract email addresses
-            emails = re.findall(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', text)
+            emails = re.findall(r'\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b', text)
             return {
                 'keywords': list(set(keywords)),
                 'email_count': len(emails),
@@ -595,3 +595,41 @@ op_topk = Operator(
     embedding_model: text-embedding-3-small
     """,
 )
+
+
+# List of all operators
+ALL_OPERATORS = [
+    op_map,
+    op_extract,
+    op_parallel_map,
+    op_filter,
+    op_reduce,
+    op_split,
+    op_gather,
+    op_unnest,
+    op_sample,
+    op_resolve,
+    op_code_map,
+    op_code_filter,
+    op_topk,
+]
+
+
+def get_all_operator_descriptions() -> str:
+    """
+    Generate a comprehensive string containing all operator descriptions.
+    This is useful for providing context about available operators in prompts.
+
+    Returns:
+        str: Formatted string containing all operator descriptions
+    """
+    descriptions = []
+    descriptions.append("# Available DocETL Operators\n")
+    descriptions.append(
+        "Below are all the operators available in the DocETL pipeline:\n"
+    )
+
+    for op in ALL_OPERATORS:
+        descriptions.append(op.to_string())
+
+    return "\n".join(descriptions)

--- a/tests/reasoning_optimizer/test_runner.py
+++ b/tests/reasoning_optimizer/test_runner.py
@@ -27,6 +27,7 @@ from docetl.reasoning_optimizer.directives import (
     ClarifyInstructionsDirective,
     SwapWithCodeDirective,
     HierarchicalReduceDirective,
+    CascadeFilteringDirective,
     TestResult
 )
 
@@ -66,6 +67,7 @@ def run_all_directive_tests(agent_llm: str = "gpt-4.1") -> Dict[str, List[TestRe
         ClarifyInstructionsDirective(),
         SwapWithCodeDirective(),
         HierarchicalReduceDirective(),
+        CascadeFilteringDirective(),
     ]
     
     all_results = {}
@@ -172,7 +174,8 @@ def run_specific_directive_test(directive_name: str, agent_llm: str = "gpt-4o-mi
         "take_head_tail": TakeHeadTailDirective(),
         "reduce_chaining": ReduceChainingDirective(),
         "clarify_instructions": ClarifyInstructionsDirective(),
-        "swap_with_code": SwapWithCodeDirective()
+        "swap_with_code": SwapWithCodeDirective(),
+        "cascade_filtering": CascadeFilteringDirective(),
     }
     
     if directive_name.lower() not in directive_map:


### PR DESCRIPTION
This PR adds 2 directives

- cascade filter: akin to task cascades (under submission), we can rewrite a filter to be a series of very cheap filters prepended before the original filter op. the cheap filters should have good recall but can narrow down the document set that the original filter needs to look at
- arbitrary rewrite: the agent can propose an arbitrary rewrite to the pipeline. i express the InstantiateSchema as a list of edits to the pipeline code, akin to [Aider's format](https://github.com/Aider-AI/aider/blob/main/aider/coders/editblock_fenced_prompts.py). the arbitrary rewrite directive will give us "completeness" of all possible rewrites

also fixed some small nits like added a `get_all_operator_descriptions` utility